### PR TITLE
Bug Fix escaping Characters in ServerConnection

### DIFF
--- a/src/StarDust.CasparCG.net.Connection/ServerConnection.cs
+++ b/src/StarDust.CasparCG.net.Connection/ServerConnection.cs
@@ -105,8 +105,8 @@ namespace StarDust.CasparCG.net.Connection
         /// <returns></returns>
         private static string EscapeChars(string command)
         {
-            Regex.Replace(@"^\\$", command, "\\\\");
-            Regex.Replace("^\r\n$", command, "\n");
+            Regex.Replace(command, @"^\\$", "\\\\");
+            Regex.Replace(command, "^\r\n$", "\n");
             return command;
         }
 


### PR DESCRIPTION
When escaping a command for sendig to a server the order of the input string and the regex patteern was swapped.
This resulted in regex errors when sending commands with data payloads conatining "[]" or "Z-A" for invalid regex patterns.