### PR TITLE
Bug Fix Exception when playing a CasparPlayingInfoItem without a transition

### DIFF
--- a/src/StarDust.CasparCg.net.Device/Manager/ChannelManager.cs
+++ b/src/StarDust.CasparCg.net.Device/Manager/ChannelManager.cs
@@ -141,7 +141,7 @@ namespace StarDust.CasparCG.net.Device
         /// <returns></returns>
         public virtual bool Play(CasparPlayingInfoItem playingInfoItem)
         {
-            return _amcpTcpParser.SendCommand($"{AMCPCommand.PLAY.ToAmcpValue()} {ID}-{playingInfoItem.VideoLayer} {playingInfoItem.Clipname} {playingInfoItem.Transition.ToString()}");
+            return _amcpTcpParser.SendCommand($"{AMCPCommand.PLAY.ToAmcpValue()} {ID}-{playingInfoItem.VideoLayer} {playingInfoItem.Clipname} {playingInfoItem.Transition?.ToString()}");
         }
 
         /// <summary>


### PR DESCRIPTION
When using Play with a CasparPlayingInfoItem without a tranistion a NullReferenceException would be raised.
In the Load function  Null-conditional operator is already used.