### PR TITLE
Add GitHub Packages alpha prerelease workflow

### DIFF
--- a/.github/workflows/package-prerelease.yml
+++ b/.github/workflows/package-prerelease.yml
@@ -11,20 +11,37 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: package-prerelease-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   pack-prerelease:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.0.x
           cache: true
           cache-dependency-path: src/**/packages.lock.json
+
       - name: Compute alpha package version
         run: echo "PACKAGE_VERSION=10.0.0-alpha.${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+
+      - name: Restore package project
+        run: dotnet restore src/StarDust.CasparCG/StarDust.CasparCG.csproj
+
       - name: Pack prerelease
-        run: dotnet pack src/StarDust.CasparCG/StarDust.CasparCG.csproj --configuration Release -p:PackageVersion=${PACKAGE_VERSION} -p:BuildInParallel=false -o artifacts/packages
+        run: dotnet pack src/StarDust.CasparCG/StarDust.CasparCG.csproj --configuration Release --no-restore -p:PackageVersion=${PACKAGE_VERSION} -p:BuildInParallel=false -o artifacts/packages
+
+      - name: Add GitHub Packages source
+        run: dotnet nuget add source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --name github --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
+
+      - name: Publish prerelease package
+        run: dotnet nuget push "artifacts/packages/*.nupkg" --source github --api-key "${{ secrets.GITHUB_TOKEN }}" --skip-duplicate
+
       - uses: actions/upload-artifact@v4
         with:
           name: prerelease-packages

--- a/.github/workflows/package-prerelease.yml
+++ b/.github/workflows/package-prerelease.yml
@@ -1,0 +1,31 @@
+name: package-prerelease
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - feature/**
+      - mr/**
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  pack-prerelease:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          cache: true
+          cache-dependency-path: src/**/packages.lock.json
+      - name: Compute alpha package version
+        run: echo "PACKAGE_VERSION=10.0.0-alpha.${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+      - name: Pack prerelease
+        run: dotnet pack src/StarDust.CasparCG/StarDust.CasparCG.csproj --configuration Release -p:PackageVersion=${PACKAGE_VERSION} -p:BuildInParallel=false -o artifacts/packages
+      - uses: actions/upload-artifact@v4
+        with:
+          name: prerelease-packages
+          path: artifacts/packages

--- a/.github/workflows/package-prerelease.yml
+++ b/.github/workflows/package-prerelease.yml
@@ -24,8 +24,6 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 10.0.x
-          cache: true
-          cache-dependency-path: src/**/packages.lock.json
 
       - name: Compute alpha package version
         run: echo "PACKAGE_VERSION=10.0.0-alpha.${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"

--- a/README.md
+++ b/README.md
@@ -87,6 +87,26 @@ var snapshot = client.State.GetSnapshot();
 | Mixer | `MIXER KEYER`, `MIXER INVERT`, `MIXER CHROMA`, `MIXER BLEND`, `MIXER OPACITY`, `MIXER BRIGHTNESS`, `MIXER SATURATION`, `MIXER CONTRAST`, `MIXER LEVELS`, `MIXER FILL`, `MIXER CLIP`, `MIXER ANCHOR`, `MIXER CROP`, `MIXER ROTATION`, `MIXER PERSPECTIVE`, `MIXER VOLUME`, `MIXER MASTERVOLUME`, `MIXER GRID`, `MIXER COMMIT`, `MIXER CLEAR`, `CHANNEL_GRID` |
 | Runtime / admin | `OSC SUBSCRIBE`, `OSC UNSUBSCRIBE`, `DIAG`, `BYE`, `KILL`, `RESTART`, `LOCK` |
 
+## Alpha packages
+
+Feature and merge request branches can publish prerelease packages to GitHub Packages using versions such as `10.0.0-alpha.<run-number>`.
+
+To consume them locally, add the GitHub Packages feed:
+
+```bash
+dotnet nuget add source "https://nuget.pkg.github.com/dust63/index.json" \
+  --name "github-dust63" \
+  --username "<github-username>" \
+  --password "<github-pat>" \
+  --store-password-in-clear-text
+```
+
+Then install the package normally:
+
+```bash
+dotnet add package StarDust.CasparCG --version 10.0.0-alpha.<run-number>
+```
+
 ## Additional guides
 
 - [Breaking changes](BREAKING_CHANGES.md)

--- a/docs/superpowers/plans/2026-06-05-github-packages-alpha-cd-plan.md
+++ b/docs/superpowers/plans/2026-06-05-github-packages-alpha-cd-plan.md
@@ -1,0 +1,266 @@
+# GitHub Packages Alpha CD Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated prerelease workflow that publishes `StarDust.CasparCG` alpha packages to GitHub Packages from `feature/**` and `mr/**` branches using version format `10.0.0-alpha.<run-number>`.
+
+**Architecture:** Keep the existing stable `package.yml` workflow unchanged and introduce a separate `package-prerelease.yml` workflow for branch-based alpha publication. Versioning stays outside the csproj by injecting `PackageVersion` during `dotnet pack`, and local consumption guidance is documented alongside the workflow.
+
+**Tech Stack:** GitHub Actions, .NET 10 CLI, NuGet/GitHub Packages, Markdown docs
+
+---
+
+## File Map
+
+- Create: `.github/workflows/package-prerelease.yml`
+- Modify: `README.md`
+- Keep unchanged but verify compatibility: `.github/workflows/package.yml`
+- Keep unchanged but use at pack time: `src/StarDust.CasparCG/StarDust.CasparCG.csproj`
+
+### Task 1: Define the alpha package workflow contract
+
+**Files:**
+- Create: `.github/workflows/package-prerelease.yml`
+
+- [ ] **Step 1: Write the failing prerelease workflow file**
+
+Create `.github/workflows/package-prerelease.yml` with this skeleton:
+
+```yaml
+name: package-prerelease
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - feature/**
+      - mr/**
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  pack-prerelease:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          cache: true
+          cache-dependency-path: src/**/packages.lock.json
+      - name: Compute alpha package version
+        run: echo "PACKAGE_VERSION=10.0.0-alpha.${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+      - name: Pack prerelease
+        run: dotnet pack src/StarDust.CasparCG/StarDust.CasparCG.csproj --configuration Release -p:PackageVersion=${PACKAGE_VERSION} -p:BuildInParallel=false -o artifacts/packages
+      - uses: actions/upload-artifact@v4
+        with:
+          name: prerelease-packages
+          path: artifacts/packages
+```
+
+- [ ] **Step 2: Verify the workflow is still incomplete**
+
+Run:
+
+```bash
+sed -n '1,240p' .github/workflows/package-prerelease.yml
+```
+
+Expected: the workflow exists but does not yet publish to GitHub Packages or document local usage.
+
+- [ ] **Step 3: Commit the workflow contract**
+
+```bash
+git add .github/workflows/package-prerelease.yml
+git commit -m "ci: add prerelease package workflow skeleton"
+```
+
+### Task 2: Add real GitHub Packages publication
+
+**Files:**
+- Modify: `.github/workflows/package-prerelease.yml`
+
+- [ ] **Step 1: Extend the workflow with explicit package source and push**
+
+Update `.github/workflows/package-prerelease.yml` so the job includes:
+
+```yaml
+      - name: Add GitHub Packages source
+        run: dotnet nuget add source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --name github --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
+
+      - name: Publish prerelease package
+        run: dotnet nuget push "artifacts/packages/*.nupkg" --source github --api-key "${{ secrets.GITHUB_TOKEN }}" --skip-duplicate
+```
+
+And the full workflow should read:
+
+```yaml
+name: package-prerelease
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - feature/**
+      - mr/**
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: package-prerelease-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pack-prerelease:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+          cache: true
+          cache-dependency-path: src/**/packages.lock.json
+
+      - name: Compute alpha package version
+        run: echo "PACKAGE_VERSION=10.0.0-alpha.${GITHUB_RUN_NUMBER}" >> "$GITHUB_ENV"
+
+      - name: Restore package project
+        run: dotnet restore src/StarDust.CasparCG/StarDust.CasparCG.csproj
+
+      - name: Pack prerelease
+        run: dotnet pack src/StarDust.CasparCG/StarDust.CasparCG.csproj --configuration Release --no-restore -p:PackageVersion=${PACKAGE_VERSION} -p:BuildInParallel=false -o artifacts/packages
+
+      - name: Add GitHub Packages source
+        run: dotnet nuget add source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json" --name github --username "${{ github.actor }}" --password "${{ secrets.GITHUB_TOKEN }}" --store-password-in-clear-text
+
+      - name: Publish prerelease package
+        run: dotnet nuget push "artifacts/packages/*.nupkg" --source github --api-key "${{ secrets.GITHUB_TOKEN }}" --skip-duplicate
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: prerelease-packages
+          path: artifacts/packages
+```
+
+- [ ] **Step 2: Verify the alpha versioning rule is present**
+
+Run:
+
+```bash
+grep -n "10.0.0-alpha" .github/workflows/package-prerelease.yml
+```
+
+Expected: one line showing `PACKAGE_VERSION=10.0.0-alpha.${GITHUB_RUN_NUMBER}`.
+
+- [ ] **Step 3: Commit the publish-capable workflow**
+
+```bash
+git add .github/workflows/package-prerelease.yml
+git commit -m "ci: publish alpha packages to github packages"
+```
+
+### Task 3: Document local consumption
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Add a short alpha package consumption section**
+
+Insert this section near the existing guide links in `README.md`:
+
+```md
+## Alpha packages
+
+Feature and MR branches can publish prerelease packages to GitHub Packages using versions like `10.0.0-alpha.<run-number>`.
+
+To consume them locally, add the GitHub Packages feed:
+
+```bash
+dotnet nuget add source "https://nuget.pkg.github.com/dust63/index.json" \
+  --name github-dust63 \
+  --username "<github-username>" \
+  --password "<github-personal-access-token>" \
+  --store-password-in-clear-text
+```
+
+Then install the package normally:
+
+```bash
+dotnet add package StarDust.CasparCG --version 10.0.0-alpha.<run-number>
+```
+```
+
+- [ ] **Step 2: Verify the docs mention GitHub Packages and alpha versioning**
+
+Run:
+
+```bash
+grep -n "Alpha packages\\|nuget.pkg.github.com\\|10.0.0-alpha" README.md
+```
+
+Expected: three matching lines or more in the new section.
+
+- [ ] **Step 3: Commit the docs update**
+
+```bash
+git add README.md
+git commit -m "docs: explain alpha package consumption"
+```
+
+### Task 4: Final validation
+
+**Files:**
+- None
+
+- [ ] **Step 1: Verify the stable workflow stayed unchanged**
+
+Run:
+
+```bash
+git diff -- .github/workflows/package.yml
+```
+
+Expected: no output.
+
+- [ ] **Step 2: Re-read the prerelease workflow**
+
+Run:
+
+```bash
+sed -n '1,260p' .github/workflows/package-prerelease.yml
+```
+
+Expected: branch triggers, `packages: write`, alpha version computation, GitHub Packages source setup, publish step, and artifact upload all present.
+
+- [ ] **Step 3: Verify docs and workflow references together**
+
+Run:
+
+```bash
+grep -n "10.0.0-alpha" .github/workflows/package-prerelease.yml README.md
+```
+
+Expected: matches in both files.
+
+- [ ] **Step 4: Inspect repo state**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: clean worktree after commits.
+
+- [ ] **Step 5: Record the outcome**
+
+Report:
+- the new workflow path
+- the trigger branches
+- the alpha version format
+- the GitHub Packages feed URL documented for local usage

--- a/docs/superpowers/specs/2026-06-05-github-packages-alpha-cd-design.md
+++ b/docs/superpowers/specs/2026-06-05-github-packages-alpha-cd-design.md
@@ -1,0 +1,86 @@
+# GitHub Packages Alpha CD Design
+
+## Summary
+
+Add a dedicated prerelease workflow that publishes `StarDust.CasparCG` alpha packages to GitHub Packages from `feature/**` and `mr/**` branches.
+
+## Goal
+
+Allow feature and MR branches to produce installable prerelease NuGet packages without polluting the public NuGet feed.
+
+## Release Model
+
+### Alpha packages
+
+- trigger on pushes to `feature/**`
+- trigger on pushes to `mr/**`
+- publish to GitHub Packages
+- version format: `10.0.0-alpha.<run-number>`
+
+The major version tracks the target .NET version, so as long as the package targets `.NET 10`, prerelease packages start with `10`.
+
+### Stable packages
+
+- remain on the existing stable release path
+- remain separate from prerelease publication logic
+
+## Architecture
+
+Use a dedicated workflow instead of extending the existing `package.yml`.
+
+This keeps:
+
+- prerelease logic isolated
+- stable publishing safer
+- branch-based experimentation easier to debug
+
+## Workflow Responsibilities
+
+The prerelease workflow should:
+
+1. check out the repository
+2. set up `.NET 10`
+3. compute the prerelease package version from `github.run_number`
+4. pack `src/StarDust.CasparCG/StarDust.CasparCG.csproj`
+5. publish the resulting package to GitHub Packages
+6. upload generated packages as workflow artifacts for inspection
+
+## Versioning Rules
+
+- package version should be injected at pack time, not hardcoded into the project file
+- `PackageVersion` should be set by workflow input to MSBuild
+- example output: `10.0.0-alpha.142`
+
+## Authentication
+
+- use repository `GITHUB_TOKEN` for GitHub Packages publishing if repository permissions allow it
+- workflow needs `packages: write`
+- workflow also needs `contents: read`
+
+## Local Consumption
+
+The design should include documentation for local usage:
+
+- GitHub Packages feed URL
+- required authentication/token setup
+- how to restore and reference alpha packages from a local project
+
+## Constraints
+
+- do not publish prerelease packages to `nuget.org`
+- do not break the current stable package workflow
+- keep the workflow explicit and easy to audit
+- avoid hidden version logic in the csproj
+
+## Affected Files
+
+- `.github/workflows/package-prerelease.yml`
+- optionally `README.md` or `docs/` for package feed usage notes
+
+## Validation
+
+- branch push on `feature/**` or `mr/**` should create an alpha package
+- generated version should match `10.0.0-alpha.<run-number>`
+- package artifact should be uploaded
+- publish target should be GitHub Packages only
+- existing stable package workflow should remain unchanged

--- a/docs/superpowers/specs/2026-06-05-github-pages-hero-site-design.md
+++ b/docs/superpowers/specs/2026-06-05-github-pages-hero-site-design.md
@@ -1,0 +1,240 @@
+# GitHub Pages Hero Site Design
+
+## Summary
+
+Publish a lightweight GitHub Pages site for `StarDust.CasparCG.net` with:
+
+- a dedicated hero landing page at `/`
+- a published documentation area at `/docs/`
+- only the public `docs/vnext/*` guides exposed on the website
+- no dependency on a frontend framework or server runtime
+
+The landing page is independent from `README.md`. It should act as the public entry point for the project, while the repository README remains optimized for GitHub readers and contributors.
+
+## Goals
+
+- Create a polished public homepage for the vNext library.
+- Publish the existing vNext guides on the same GitHub Pages site.
+- Keep the site generation and deployment pipeline simple and durable.
+- Preserve a clean separation between public documentation and internal project notes.
+
+## Non-Goals
+
+- Introducing a JS framework such as Docusaurus or a static site generator such as MkDocs.
+- Publishing internal `docs/superpowers/*` planning and design files.
+- Replacing the repository `README.md` with the website homepage.
+- Building a dynamic search engine, blog, or server-rendered site.
+
+## User Experience
+
+### Homepage
+
+The root page `/` is a product-facing hero page with a technical follow-through. It should quickly communicate:
+
+- this is a modern .NET client for CasparCG
+- it supports async command execution, dependency injection, events, and testing
+- it provides fluent APIs over AMCP and OSC workflows
+
+The page should start with a strong visual hero inspired by the Stitch project `Hero Stardust.CasparCg`, then move rapidly into concrete value:
+
+- a short code sample
+- capability highlights
+- links to the main documentation guides
+- a short section describing the library surface and repository structure
+
+This is a mixed product and technical homepage, not a pure marketing page.
+
+### Documentation Area
+
+The `/docs/` section exposes only public vNext guides:
+
+- `getting-started`
+- `fluent-api-cookbook`
+- `events-and-state`
+- `hosting-and-di`
+- `testing-with-dummy-server`
+
+The docs experience should stay minimal:
+
+- shared header or top navigation with a link back to `/`
+- a simple docs index page
+- readable typography and code block styling
+- consistent visual language with the homepage
+
+## Information Architecture
+
+### Public Routes
+
+- `/`
+  - homepage
+- `/docs/`
+  - docs index
+- `/docs/getting-started/`
+- `/docs/fluent-api-cookbook/`
+- `/docs/events-and-state/`
+- `/docs/hosting-and-di/`
+- `/docs/testing-with-dummy-server/`
+
+### Source Boundaries
+
+- `README.md`
+  - remains GitHub-focused and is not used as the website source
+- `docs/vnext/*.md`
+  - remain the source of truth for public guides
+- `docs/superpowers/**`
+  - remain internal and unpublished
+
+## Architecture
+
+### Source Layout
+
+Add a dedicated website source area, for example:
+
+- `site-src/`
+  - homepage source files
+  - shared templates or partials
+  - static assets such as CSS, JS, and images
+  - docs page shell assets
+
+Generate the final published output into a separate static directory inside the repository, for example `site/`, so it can be validated locally before deployment and clearly distinguished from hand-authored site sources.
+
+## Generation Model
+
+Use a lightweight build script to assemble the published site:
+
+1. generate the homepage from static source files
+2. convert or wrap each `docs/vnext/*.md` file into a published HTML page under `/docs/`
+3. generate a docs index page
+4. copy shared CSS, JS, and assets into the output directory
+
+The generation flow must stay deterministic and transparent. A contributor should be able to understand the site build without learning a framework-specific convention system.
+
+## Document Conversion
+
+The docs are published as a simple mirror of the existing public Markdown guides. Since the chosen approach is intentionally lightweight, the conversion layer should be minimal and predictable:
+
+- preserve heading hierarchy from the Markdown source
+- preserve fenced code blocks
+- preserve inline code, lists, and links
+- add a lightweight shared page shell around each converted document
+
+If a Markdown conversion dependency is needed, prefer a small, well-understood tool over a framework runtime.
+
+## Visual Direction
+
+The public site should borrow from the approved Stitch direction:
+
+- dark-first presentation
+- high contrast surfaces
+- terminal-green accent color
+- modern technical typography
+- prominent code blocks and architectural feeling
+
+The homepage should feel intentional and premium, but still appropriate for a .NET developer library. It should avoid generic template styling and avoid over-animated behavior.
+
+## Components
+
+### Homepage Sections
+
+- hero section with title, subtitle, and primary actions
+- featured C# snippet
+- capability grid
+- documentation entry section
+- repository structure or feature summary section
+
+### Shared Chrome
+
+- compact site header
+- shared footer or lightweight closing section
+- docs navigation back to homepage
+
+### Docs Shell
+
+- page title
+- optional short intro
+- content area for rendered Markdown
+- simple next-step links back to docs index or homepage
+
+## Deployment
+
+Deploy through GitHub Pages using a GitHub Actions workflow.
+
+The workflow should:
+
+1. build the static site output
+2. validate required pages and links
+3. publish the generated directory to GitHub Pages
+
+The deployment flow must not publish private planning documents or unrelated repository content.
+
+## Validation
+
+Add lightweight validation around the static site build:
+
+- required homepage file exists
+- required docs pages exist
+- homepage links to `/docs/`
+- docs index links to all published vNext guides
+- generated output excludes `docs/superpowers/*`
+
+Validation should fail loudly if expected files are missing or if the build would produce an incomplete public site.
+
+## Risks And Mitigations
+
+### Risk: visual mismatch between homepage and docs
+
+Mitigation:
+
+- use shared CSS tokens and shared top-level layout structure
+- keep docs shell intentionally minimal but clearly part of the same site
+
+### Risk: duplicated messaging between README and homepage
+
+Mitigation:
+
+- keep `README.md` repo-focused
+- keep homepage public-facing and narrative
+
+### Risk: accidental publication of internal docs
+
+Mitigation:
+
+- whitelist `docs/vnext/*` explicitly instead of publishing the whole `docs/` tree
+
+### Risk: fragile build pipeline
+
+Mitigation:
+
+- use a small script-based build
+- keep dependencies minimal
+- validate the generated output structure
+
+## Testing Strategy
+
+Use repository-level checks appropriate for a static site slice:
+
+- build script verification
+- generated file existence checks
+- simple link validation for main internal links
+
+The site work should not require introducing a heavy frontend toolchain unless a future change justifies it.
+
+## Open Decisions Resolved
+
+- GitHub Pages hosts both landing page and docs: yes
+- Homepage path: `/`
+- Docs path: `/docs/`
+- Homepage source derived from README: no
+- Docs publication scope: only `docs/vnext/*`
+- Homepage style: mixed product and technical
+- Primary message: modern .NET client for CasparCG
+- Technical stack: lightweight static site
+
+## Expected Outcome
+
+After implementation, the repository will have:
+
+- a public GitHub Pages homepage for `StarDust.CasparCG.net`
+- a simple but coherent `/docs/` area for vNext guides
+- a lightweight generation and deployment workflow
+- a clean separation between public docs and internal design records


### PR DESCRIPTION
## Summary
- add a dedicated `package-prerelease` workflow for `feature/**` and `mr/**` branches
- publish `StarDust.CasparCG` alpha packages to GitHub Packages as `10.0.0-alpha.<run-number>`
- document how to consume alpha packages locally from the GitHub Packages feed
- disable built-in `setup-dotnet` caching in the prerelease workflow to avoid post-job cache failures

## Validation
- `dotnet pack src/StarDust.CasparCG/StarDust.CasparCG.csproj --configuration Release -p:PackageVersion=10.0.0-alpha.123 -p:BuildInParallel=false -o artifacts/packages-alpha-test`
- `dotnet pack src/StarDust.CasparCG/StarDust.CasparCG.csproj --configuration Release -p:PackageVersion=10.0.0-alpha.456 -p:BuildInParallel=false -o artifacts/packages-alpha-verify`
- verified `.github/workflows/package.yml` stayed unchanged
- confirmed the previous workflow failure came from `Post Run actions/setup-dotnet@v4` cache save, not package publication